### PR TITLE
Modernise build system and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,20 @@ python-recutils
 
 Python bindings for librec, the C library of GNU Recutils.
 
-You can install the bindings using "python setup.py install" or using "sudo pip install python-recutils/" if you have pip installed.
-Once installed, you can check how it works by running the test files as "python testfile_name.py".
-For the manual type "info python_recutils.info".
+The build system now relies on ``setuptools``.  Install the bindings with::
+
+    python -m pip install .
+
+You can also use ``poetry`` to manage a development environment::
+
+    poetry install
+
+After installation run the test-suite using::
+
+    python -m unittest
+
+Or with ``poetry``::
+
+    poetry run python -m unittest
+
+For the manual type ``info python_recutils.info``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.poetry]
+name = "python-recutils"
+version = "1.5"
+description = "Python bindings for GNU recutils"
+authors = ["Maninya M."]
+packages = [{ include = "pyrec" }]
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = ">=2.7"
+
+[tool.poetry.dev-dependencies]

--- a/pyrec.py
+++ b/pyrec.py
@@ -1,66 +1,71 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import sys
 import recutils
 import os, errno
 
 class Recdb(recutils.recdb):
- 	def __init__(self):
-		pass
+    def __init__(self):
+        pass
 
-	def loadfile(self, filename):
-		try:
-			self.pyloadfile(filename)	
-		except recutils.error as e:
-			print 'File load failed:', e
+    def loadfile(self, filename):
+        try:
+            self.pyloadfile(filename)
+        except recutils.error as e:
+            print('File load failed:', e)
 
-	def writefile(self, filename):
-		try:
-			self.pywritefile(filename)	
-		except recutils.error as e:
-			print 'File write failed:', e
+    def writefile(self, filename):
+        try:
+            self.pywritefile(filename)
+        except recutils.error as e:
+            print('File write failed:', e)
 
-	def appendfile(self, filename):
-		try:
-			self.pyappendfile(filename)	
-		except recutils.error as e:
-			print 'File append failed:', e
+    def appendfile(self, filename):
+        try:
+            self.pyappendfile(filename)
+        except recutils.error as e:
+            print('File append failed:', e)
 
-	def insert_rset(self, recset, position):
-		try:
-			self.pyinsert_rset(recset, position)	
-		except recutils.error as e:
-			print e
+    def insert_rset(self, recset, position):
+        try:
+            self.pyinsert_rset(recset, position)
+        except recutils.error as e:
+            print(e)
 
-	def remove_rset(self, position):
-		try:
-			self.pyremove_rset(position)	
-		except recutils.error as e:
-			print e
+    def remove_rset(self, position):
+        try:
+            self.pyremove_rset(position)
+        except recutils.error as e:
+            print(e)
 	
 	
 class Fexenum(recutils.fex):
- 	(REC_FEX_SIMPLE, REC_FEX_CSV, REC_FEX_SUBSCRIPTS) = range(0,3)
+    (REC_FEX_SIMPLE, REC_FEX_CSV, REC_FEX_SUBSCRIPTS) = range(3)
 
 class RecSetenum(recutils.recdb):
- 	(REC_SET_ACT_NONE, REC_SET_ACT_RENAME, 
- 	 REC_SET_ACT_SET, REC_SET_ACT_ADD, 
- 	 REC_SET_ACT_SETADD, REC_SET_ACT_DELETE, REC_SET_ACT_COMMENT) = range(0,7)
+    (
+        REC_SET_ACT_NONE,
+        REC_SET_ACT_RENAME,
+        REC_SET_ACT_SET,
+        REC_SET_ACT_ADD,
+        REC_SET_ACT_SETADD,
+        REC_SET_ACT_DELETE,
+        REC_SET_ACT_COMMENT,
+    ) = range(7)
 
 
 
 class RecSex(recutils.sex):
-	 	
-	def compile(self, expr):
-		try:
-			self.pycompile(expr)	
-		except recutils.error as e:
-			print e
+    def compile(self, expr):
+        try:
+            self.pycompile(expr)
+        except recutils.error as e:
+            print(e)
 
-	def eval(self, rec, status):
-		try:
-			self.pyeval(rec, status)	
-		except recutils.error as e:
-			print e
+    def eval(self, rec, status):
+        try:
+            self.pyeval(rec, status)
+        except recutils.error as e:
+            print(e)
 
 
 		

--- a/setup.py
+++ b/setup.py
@@ -22,14 +22,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 setup(
     name = 'recutils', 
     version = '1.5',
     py_modules=['pyrec'],
-    ext_modules = [
-        Extension('recutils', ['recutils.c'],
-                  libraries = [ 'rec' ],
-                  ),
-      ],
-) 
+    ext_modules=[
+        Extension(
+            'recutils',
+            ['recutils.c'],
+            libraries=['rec'],
+        ),
+    ],
+    python_requires='>=2.7',
+)

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,15 @@
+import importlib
+import sys
+import unittest
+from unittest import mock
+
+
+class ImportTests(unittest.TestCase):
+    def test_pyrec_imports_without_recutils(self):
+        with mock.patch.dict(sys.modules, {'recutils': mock.MagicMock()}):
+            module = importlib.import_module('pyrec')
+            self.assertTrue(hasattr(module, 'Recdb'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- update README instructions
- switch build to setuptools with PEP 517 `pyproject.toml`
- clean up `pyrec.py` for Python3 compatibility
- add unit test harness that mocks the extension
- add Poetry configuration for development and testing

## Testing
- `python -m unittest discover -v tests`


------
https://chatgpt.com/codex/tasks/task_e_68545164f7148320a7b7e368b1aa748e